### PR TITLE
Lost Cities Pass

### DIFF
--- a/config/lostcities/profile_bio_wasteland.cfg
+++ b/config/lostcities/profile_bio_wasteland.cfg
@@ -250,7 +250,7 @@ lostcity_bio_wasteland {
     B:avoidGeneratedMushrooms=false
 
     # This will prevent biomes from generating pumpkins [default: false]
-    B:avoidGeneratedPumpkins=true
+    B:avoidGeneratedPumpkins=false
 
     # This will prevent biomes from generating reeds [default: true]
     B:avoidGeneratedReeds=false
@@ -501,7 +501,7 @@ structures_bio_wasteland {
     B:preventLakesRavinesInCities=false
 
     # If true then an attempt will be made to prevent villages in cities. Note that enabling this option will likely require a low city density in order to actually get a reasonable chance for villages.
-    B:preventVillagesInCities=false
+    B:preventVillagesInCities=true
 }
 
 


### PR DESCRIPTION
Allow Pumpkins to Generate in Wasteland where possible

Prevent Villages from Spawning In City since it looks derpy, this should stop villager buildings from spawling halfway up a skyscraper