### PR TITLE
Mob Spawning Updates

### DIFF
--- a/config/incontrol/potentialspawn.json
+++ b/config/incontrol/potentialspawn.json
@@ -1,1 +1,28 @@
-[]
+[
+	{
+		"_comment": "I'm disabling this due to how fast and annoying it is",
+		"remove":"techguns:alienbug"
+	},
+	{
+		"_comment": "Extremely strong and acurate, disabled for now",
+		"remove": "techguns:zombiepigmansoldier"
+	},
+	{
+		"_comment":"Adds Wither Skeletons as valid spawns in Ominous Woods",			
+		"biome": "ominous_woods",
+		"mobs": [
+			{
+				"mob": "minecraft:wither_skeleton",
+				"weight": 4,
+				"groupcountmin": 1,
+				"groupcountmax": 3
+			},
+			{
+				"mob": "minecraft:cave_spider",
+				"weight": 5,
+				"groupcountmin": 1,
+				"groupcountmax": 3
+			}
+		]
+	}
+]

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -1,1 +1,35 @@
-[]
+[
+	{
+		"_comment":"Disables Modded Entities from Spawning in Spheres",
+		"mob": [
+			"cyberware:cyberzombie", "rewired:cyber_skeleton", "techguns:armysoldier","techguns:bandit","techguns:commando","techguns:cyberdemon","techguns:attackhelicopter","techguns:dictatordave","techguns:outcast","techguns:psychosteve","techguns:skeletonsoldier","techguns:stormtrooper","techguns:supermutantbasic","techguns:supermutantheavy","techguns:supermutantelite","techguns:zombiefarmer","techguns:zombieminer","techguns:zombiesoldier","thermalfoundation:basalz","thermalfoundation:blitz","thermalfoundation:blizz"
+		],
+		"insphere": true,
+		"result": "deny"
+
+	},
+	{
+		"_comment":"Techguns Soldiers to spawn only in the ruins of cities",
+		"mob": [
+			"techguns:armysoldier","techguns:bandit","techguns:commando","techguns:cyberdemon","techguns:dictatordave","techguns:outcast","techguns:psychosteve","techguns:stormtrooper"
+		],
+		"incity": false,
+		"result": "deny"
+	},
+	{
+		"_comment": "Techguns Hard Mobs spawn only below ground",
+		"mob": [
+			"techguns:supermutantbasic","techguns:supermutantbasic","techguns:supermutantheavy","techguns:cyberdemon"
+		],
+		"minheight": 60,
+		"result": "deny"
+	},
+	{
+		"_comment": "Techguns Hard Mobs spawn only outside of Spheres",
+		"mob": [
+			"techguns:supermutantbasic","techguns:supermutantbasic","techguns:supermutantheavy","techguns:cyberdemon"
+		],
+		"insphere": true,
+		"result": "deny"
+	}
+]

--- a/config/lostsouls.cfg
+++ b/config/lostsouls.cfg
@@ -60,7 +60,7 @@ general {
     S:messageBuildingHalfway=About half way there! Keep going!
 
     # This message is given when the player enters a haunted building for the first time [default: This building is haunted. Be careful!]
-    S:messageBuildingHaunted=This building is haunted. Be careful!
+    S:messageBuildingHaunted=This building is swarming with enemies. Be careful!
 
     # This message is given when the player tries to open a chest in a haunted building [default: The building isn't safe enough!]
     S:messageUnsafeBuilding=The building isn't safe enough!
@@ -79,6 +79,9 @@ general {
 
     # List of mobs that can spawn in buildings together with their rarity [default: [.3=minecraft:zombie], [.3=minecraft:spider], [.3=minecraft:skeleton], [.2=minecraft:husk], [.2=minecraft:stray], [.1=minecraft:witch], [.1=minecraft:enderman]]
     S:mobs <
+        .2=techguns:bandit
+        .1=techguns:soldier        
+        .05=techguns:commando
         .3=minecraft:zombie
         .3=minecraft:spider
         .3=minecraft:skeleton
@@ -90,45 +93,46 @@ general {
 
     # List of boots that the mobs can have together with their rarity [default: [.3=null], [.3=minecraft:diamond_boots], [.3=minecraft:iron_boots]]
     S:randomBoots <
-        .3=null
-        .3=minecraft:diamond_boots
+        .3=null        
         .3=minecraft:iron_boots
+        .3=techguns:t1_scout_boots
      >
 
     # List of chestplates that the mobs can have together with their rarity [default: [.3=null], [.3=minecraft:diamond_chestplate], [.3=minecraft:iron_chestplate]]
     S:randomChestplates <
-        .3=null
-        .3=minecraft:diamond_chestplate
+        .3=null        
         .3=minecraft:iron_chestplate
+        .3=techguns:t1_scout_chestplate
      >
 
     # List of effects that a mob can have. Note that multiple effects are possible [default: [.3=minecraft:regeneration,3], [.3=minecraft:speed,3], [.3=minecraft:fire_resistance,3]]
     S:randomEffects <
-        .3=minecraft:regeneration,3
-        .3=minecraft:speed,3
+        .3=minecraft:regeneration,2        
         .3=minecraft:fire_resistance,3
      >
 
     # List of helmets that the mobs can have together with their rarity [default: [.3=null], [.3=minecraft:diamond_helmet], [.3=minecraft:iron_helmet]]
     S:randomHelmets <
-        .3=null
-        .3=minecraft:diamond_helmet
+        .3=null        
         .3=minecraft:iron_helmet
+        .3=techguns:t1_scout_helmet
      >
 
     # List of leggings that the mobs can have together with their rarity [default: [.3=null], [.3=minecraft:diamond_leggings], [.3=minecraft:iron_leggings]]
     S:randomLeggings <
-        .3=null
-        .3=minecraft:diamond_leggings
+        .3=null        
         .3=minecraft:iron_leggings
+        .3=techguns:t1_scout_leggings
      >
 
     # List of weapons that the mobs can have together with their rarity [default: [.3=null], [.3=minecraft:diamond_sword], [.3=minecraft:iron_sword], [.3=minecraft:bow]]
     S:randomWeapons <
         .3=null
-        .3=minecraft:diamond_sword
+        .2=techguns:crowbar
         .3=minecraft:iron_sword
         .3=minecraft:bow
+        .05=techguns:chainsaw
+        .2=cyberware:katana    
      >
 
     # The amount of ticks that the server waits before checking for new spawns [range: 1 ~ 1000000, default: 200]


### PR DESCRIPTION
Removed Diamond Armor from Lost Souls Mobs, replaced with Bandit Armor from Tech Guns, fits the wasteland theme

Removed Speed from Lost Souls Mobs, It hurts. So much

Removed Diamond Sword from Lost Souls Weapons. Added Crowbar,  Katana, and Chainsaw.

Added Techguns Bandit, Soldier, and Commando to the list of valid haunted mobs

Initial Pass on InControl Rules for Wasted

Disabled Modded Entities from spawning in Spheres

Only allow Techguns Soldier Entities to spawn in Cities

Restricted Hard Techguns Entities to below ground outside of Spheres

Disabled Alien Bug and Zombie Pigman Soldier due to difficulty

Added wither skeleton and cave spider to ominous_woods spawn list.