### PR TITLE
HungerOverhaul Tweaks

### DIFF
--- a/config/hungeroverhaul/HungerOverhaul.cfg
+++ b/config/hungeroverhaul/HungerOverhaul.cfg
@@ -125,7 +125,7 @@ food {
 
     # Food values not manually set (see 'useHOFoodValues') will have their saturation modifier set to <modified hunger> divided by this ('modifyFoodValues' must be true)
     # Set to 0 to disable [vanilla: 0.0] [range: -3.4028235E38 ~ 3.4028235E38, default: 20.0]
-    S:foodHungerToSaturationDivider=1.0
+    S:foodHungerToSaturationDivider=20.0
 
     # Food values not manually set (see 'useHOFoodValues') will have their saturation modifier divided by this ('modifyFoodValues' must be true)
     # Note: Gets applied after 'foodHungerToSaturationDivider' [vanilla: 1.0] [range: -3.4028235E38 ~ 3.4028235E38, default: 1.0]
@@ -197,7 +197,7 @@ harvestcraft {
     B:addCropTradesFarmer=true
 
     # HarvestCraft items added to dungeon/temple chests (Harvestcraft) [vanilla: false] [default: true]
-    B:addHarvestCraftChestLoot=true
+    B:addHarvestCraftChestLoot=false
 
     # Add HarvestCraft saplings to the items farmer villagers will sell (HarvestCraft) [vanilla: false] [default: true]
     B:addSaplingTradesFarmer=true


### PR DESCRIPTION
Increase Food Saturation Divisor to 20. This GREATLY nerfs some of the extreme saturation

Disabled Harvestcraft items in chests