### PR TITLE
Adds Ender Ore to T1 Void Miner

### DIFF
--- a/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
+++ b/config/environmentaltech/multiblocks/void_miner/ore/tier_1.json
@@ -439,6 +439,11 @@
       "target": "black",
       "weight": 4,
       "id": "environmentaltech:lonsdaleite_crystal"
+    },
+    {
+        "target": "green",
+        "weight": 120,
+        "id": "contenttweaker:sub_block_holder_0"
     }
   ]
 }


### PR DESCRIPTION
"sub_block_holder_0" is ender ore, why? Because thats its ID in the content tweaker configs