### PR TITLE
Tesla Powered Thingies Ejecting Stopped

### DIFF
--- a/config/teslacorelib.cfg
+++ b/config/teslacorelib.cfg
@@ -4,7 +4,7 @@ flags {
     # Specifies if tesla machines are allowed to spawn items in world in case their output inventory is full.
     # Warning: some machines will cause the items to be lost if not spawned in the world (WIP).
     #  [default: true]
-    B:allowMachinesToSpawnItems=true
+    B:allowMachinesToSpawnItems=flase
 
     # Specifies if the simple tesla battery item will be registered or not.
     #  [default: true]


### PR DESCRIPTION
Stops TPT machines from ejecting items when the output is full, does not stop machine from running. (Saves server overload if chunloaded)